### PR TITLE
(not a signature): correct mistake in appendix page

### DIFF
--- a/appendix/index.html
+++ b/appendix/index.html
@@ -563,7 +563,7 @@
         </div>
       </div>
       <p>
-        Later, in response to a supportive Russian-language reply, he claimed
+        Later, in response to a supportive Ukrainian-language reply, he claimed
         that the banned accounts supported Trump, and that the users operating
         them are Russian state actors.
       </p>


### PR DESCRIPTION
the comment he replied to was actually written in ukrainian, and not in russian. the letter should be as accurate and non-biased as possible, so i fixed the mistake.